### PR TITLE
Add support for config remote loading

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"standards/rules/aggregate"
 
 	"gopkg.in/yaml.v3"
@@ -64,13 +63,12 @@ type ArgoCDConfig struct {
 func New(path string) (*Config, error) {
 	var raw rawConfig
 
-	// TODO: supports path URL, exemple --config=https://google.com
-
-	file, err := os.ReadFile(path)
+	content, err := getConfigYaml(path)
 	if err != nil {
-		return nil, fmt.Errorf("Could not find config file: %v", err)
+		return nil, err
 	}
-	err = yaml.Unmarshal(file, &raw)
+
+	err = yaml.Unmarshal(content, &raw)
 	if err != nil {
 		return nil, err
 	}

--- a/config/utils.go
+++ b/config/utils.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func getConfigYaml(path string) ([]byte, error) {
+	if strings.HasPrefix(path, "http") {
+		res, err := http.Get(path)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		resBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		return resBody, nil
+	}
+
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return []byte{}, fmt.Errorf("Could not find config file: %v", err)
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
# Description

You can now load the config from remote source to support new use cases like global config within a company.

Usage:
```
# Remote
go run . run --config=https://mylocalconfig/config.yaml
# Locally
go run . run --config=config.yaml
```