### PR TITLE
Support labels on projects

### DIFF
--- a/checks/aggregates/types.go
+++ b/checks/aggregates/types.go
@@ -24,4 +24,5 @@ type Group struct {
 type ProjectResult struct {
 	Name         string
 	CheckResults []CheckResult
+	Labels       map[string]string
 }

--- a/checks/checker.go
+++ b/checks/checker.go
@@ -33,10 +33,8 @@ func NewChecker(ruler Ruler, checks []aggregates.Check, groups []aggregates.Grou
 func (c *Checker) Run(ctx context.Context, projects []providerstypes.Project) []aggregates.ProjectResult {
 	projectResults := make([]aggregates.ProjectResult, len(projects))
 	for i, project := range projects {
-		// TODO
-		// the project should be passed to every layers because the rules should be executed for
-		// each project
 		projectResult := aggregates.ProjectResult{
+			Labels:       project.Labels,
 			Name:         project.Name,
 			CheckResults: []aggregates.CheckResult{},
 		}

--- a/metrics/project.go
+++ b/metrics/project.go
@@ -32,14 +32,18 @@ func New(registry *prometheus.Registry, extraLabels []string) (*Project, error) 
 
 func (p *Project) LoadProjectsMetrics(results []aggregates.ProjectResult) {
 	for _, project := range results {
+		projectLabels := project.Labels
 		for _, result := range project.CheckResults {
 			labels := prometheus.Labels{"name": result.Name, "project": project.Name}
 			for _, label := range p.extraLabels {
+				labels[label] = ""
 				value, ok := result.Labels[label]
 				if ok {
 					labels[label] = value
-				} else {
-					labels[label] = ""
+				}
+				projectValue, ok := projectLabels[label]
+				if ok {
+					labels[label] = projectValue
 				}
 			}
 			gaugeValue := 0

--- a/providers/aggregates/provider.go
+++ b/providers/aggregates/provider.go
@@ -11,4 +11,5 @@ type Project struct {
 	URL    string
 	Branch string
 	Path   string
+	Labels map[string]string
 }

--- a/providers/argocd/root.go
+++ b/providers/argocd/root.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
@@ -54,6 +55,7 @@ func (c *Client) FetchProjects(ctx context.Context) ([]aggregates.Project, error
 	if err != nil {
 		return nil, err
 	}
+	c.logger.Debug(fmt.Sprintf("found %d ArgoCD projects", len(apps.Items)))
 	result := make([]aggregates.Project, len(apps.Items))
 	for i, app := range apps.Items {
 		result[i] = aggregates.Project{
@@ -61,6 +63,7 @@ func (c *Client) FetchProjects(ctx context.Context) ([]aggregates.Project, error
 			URL:    app.Spec.Source.RepoURL,
 			Branch: app.Spec.Source.TargetRevision,
 			Path:   path.Join(c.config.BasePath, app.Name),
+			Labels: app.Labels,
 		}
 	}
 	return result, nil


### PR DESCRIPTION
Allow passing labels to prometheus metrics from projects labels. For the ArgoCD provider, projects labels will be the ArgoCD application labels.