### PR TITLE
Optionally expose the configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 standards
 standards-insights
 /config.yaml
+*.tgz

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -21,7 +21,7 @@ func batchCmd(configPath, logLevel, logFormat *string) *cobra.Command {
 		Short: "Run checks on all projects",
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := buildLogger(*logLevel, *logFormat)
-			config, err := config.New(*configPath)
+			config, _, err := config.New(*configPath)
 			exit(err)
 
 			logger.Info(build.VersionMessage())

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,7 +27,7 @@ func runCmd(configPath *string, logLevel, logFormat *string) *cobra.Command {
 
 func RunLocalCheck(configPath, logLevel, logFormat *string) {
 	logger := buildLogger(*logLevel, *logFormat)
-	config, err := config.New(*configPath)
+	config, _, err := config.New(*configPath)
 	exit(err)
 
 	logger.Info(build.VersionMessage())

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -28,7 +28,7 @@ func serverCmd(configPath, logLevel, logFormat *string) *cobra.Command {
 		Short: "Run server",
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := buildLogger(*logLevel, *logFormat)
-			config, err := config.New(*configPath)
+			config, rawConfig, err := config.New(*configPath)
 			exit(err)
 
 			logger.Info(build.VersionMessage())
@@ -37,7 +37,7 @@ func serverCmd(configPath, logLevel, logFormat *string) *cobra.Command {
 			if !ok {
 				exit(errors.New("fail to use the Prometheus default registerer"))
 			}
-			server, err := http.New(registry, logger, config.HTTP)
+			server, err := http.New(registry, logger, config.HTTP, rawConfig)
 			exit(err)
 
 			signals := make(chan os.Signal, 1)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,8 @@ http:
   ca-cert-path: "/tmp/cacert.pem"
   insecure-skip-verify: false
   client-auth-type: "RequireAndVerifyClientCert"
+  # expose the config on /config
+  expose-configuration: false
 
 labels:
   - category

--- a/config/config.go
+++ b/config/config.go
@@ -55,21 +55,21 @@ type Group struct {
 	When   []string
 }
 
-func New(path string) (*Config, error) {
+func New(path string) (*Config, []byte, error) {
 	var config Config
 
 	content, err := getConfigYaml(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = yaml.Unmarshal(content, &config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	err = validate(config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &config, nil
+	return &config, content, nil
 }

--- a/config/http.go
+++ b/config/http.go
@@ -1,14 +1,15 @@
 package config
 
 type HTTPConfig struct {
-	Host               string `validate:"required"`
-	Port               uint32 `validate:"required,gt=1024,lt=65535"`
-	WriteTimeout       int    `yaml:"write-timeout" validate:"gt=-1,lt=60"`
-	ReadTimeout        int    `yaml:"read-timeout" validate:"gt=-1,lt=60"`
-	ReadHeaderTimeout  int    `yaml:"read-header-timeout" validate:"gt=-1,lt=60"`
-	CertPath           string `yaml:"cert-path" validate:"omitempty,file"`
-	KeyPath            string `yaml:"key-path" validate:"omitempty,file"`
-	CacertPath         string `yaml:"ca-cert-path" validate:"omitempty,file"`
-	InsecureSkipVerify bool   `yaml:"insecure-skip-verify"`
-	ClientAuthType     string `yaml:"client-auth-type" validate:"omitempty,oneof=NoClientCert RequestClientCert RequireAnyClientCert VerifyClientCertIfGiven RequireAndVerifyClientCert"`
+	ExposeConfiguration bool   `yaml:"expose-configuration"`
+	Host                string `validate:"required"`
+	Port                uint32 `validate:"required,gt=1024,lt=65535"`
+	WriteTimeout        int    `yaml:"write-timeout" validate:"gt=-1,lt=60"`
+	ReadTimeout         int    `yaml:"read-timeout" validate:"gt=-1,lt=60"`
+	ReadHeaderTimeout   int    `yaml:"read-header-timeout" validate:"gt=-1,lt=60"`
+	CertPath            string `yaml:"cert-path" validate:"omitempty,file"`
+	KeyPath             string `yaml:"key-path" validate:"omitempty,file"`
+	CacertPath          string `yaml:"ca-cert-path" validate:"omitempty,file"`
+	InsecureSkipVerify  bool   `yaml:"insecure-skip-verify"`
+	ClientAuthType      string `yaml:"client-auth-type" validate:"omitempty,oneof=NoClientCert RequestClientCert RequireAnyClientCert VerifyClientCertIfGiven RequireAndVerifyClientCert"`
 }


### PR DESCRIPTION
Add in the config a new "expose-configuration" option. If set to true, the configuration file will be exposed on /config.