### PR TITLE
Increase CI lint timeout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,5 +15,5 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.2
-          args: --timeout=3m
+          args: --timeout=5m
           skip-cache: false


### PR DESCRIPTION
Lint is failing today sometimes after 3min due to timeout