### PR TITLE
New grep module for rules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: 1.21
 
       - name: Set up QEMU for ARM64 build
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,6 @@ jobs:
           go-version: 1.21
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2
           args: --timeout=5m
           skip-cache: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 
 ARG HOME=/app
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,6 +74,13 @@ checks:
       owner: backend
     rules:
       - go-main
+  - name: grep-test
+    labels:
+      category: misc
+      severity: minor
+      owner: backend
+    rules:
+      - grep-rule-fn
 
 rules:
   - name: golang-projects
@@ -88,4 +95,10 @@ rules:
     files:
       - path: "main.go"
         contains: "^(func main)"
+  - name: grep-rule-fn
+    grep:
+      - path: "."
+        recursive: true
+        pattern: "NewGrepRule"
+        match: true
 

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type ArgoCDConfig struct {
 type Rule struct {
 	Name   string `validate:"required"`
 	Files  []FileRule
+	Grep   []GrepRule
 	Simple *bool
 }
 
@@ -41,6 +42,13 @@ type FileRule struct {
 	Contains    *types.Regexp
 	NotContains *types.Regexp `yaml:"not-contains"`
 	Exists      *bool
+}
+
+type GrepRule struct {
+	Path      string `validate:"required"`
+	Recursive bool
+	Pattern   string `validate:"required"`
+	Match     bool
 }
 
 type Check struct {

--- a/doc/rules/grep.md
+++ b/doc/rules/grep.md
@@ -1,0 +1,23 @@
+# Grep
+
+This module allows you to configure assertions on file or directories content using the `grep` command line tool.
+You need the `grep` executable in your path for this module to work.
+
+Example:
+
+```yaml
+rules:
+  - name: grepp-example
+    grep:
+      - path: "/tmp"
+        pattern: "hello*"
+        recursive: true
+        match: true
+```
+
+Available options are:
+
+- `path`: the file or directory to check (mandatory)
+- `pattern`: the string pattern to search for (mandatory)
+- `recursive`: recursively search subdirectories listed (grep `-r`option)
+- `match`: if set to true, the module will be successful if the pattern is found. Default to false, where the module will be successful if the pattern is **not** found.

--- a/pkg/ruler/builder.go
+++ b/pkg/ruler/builder.go
@@ -25,6 +25,9 @@ func newRule(config config.Rule) *rule {
 	for _, fileConfig := range config.Files {
 		modules = append(modules, rules.NewFileRule(fileConfig))
 	}
+	for _, grepConfig := range config.Grep {
+		modules = append(modules, rules.NewGrepRule(grepConfig))
+	}
 	if config.Simple != nil {
 		value := *config.Simple
 		modules = append(modules, rules.NewSimpleRule(value))

--- a/pkg/ruler/rules/grep.go
+++ b/pkg/ruler/rules/grep.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/qonto/standards-insights/config"
+	"github.com/qonto/standards-insights/pkg/project"
+)
+
+type GrepRule struct {
+	Path      string
+	Recursive bool
+	Pattern   string
+	Match     bool
+}
+
+func NewGrepRule(config config.GrepRule) *GrepRule {
+	return &GrepRule{
+		Path:      config.Path,
+		Recursive: config.Recursive,
+		Pattern:   config.Pattern,
+		Match:     config.Match,
+	}
+}
+
+func (rule *GrepRule) Do(ctx context.Context, project project.Project) error {
+	arguments := []string{}
+	if rule.Recursive {
+		arguments = append(arguments, "-r")
+	}
+	arguments = append(arguments, rule.Pattern, rule.Path)
+
+	cmd := exec.CommandContext(ctx, "grep", arguments...) //nolint
+
+	var stdErrBuffer bytes.Buffer
+	var stdOutBuffer bytes.Buffer
+	cmd.Stderr = &stdErrBuffer
+	cmd.Stdout = &stdOutBuffer
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode := exitErr.ExitCode()
+			// grep returns 1 if no match
+			if exitCode == 1 && !rule.Match {
+				return nil
+			}
+			if exitCode == 1 && rule.Match {
+				return fmt.Errorf("no match for pattern %s on path %s", rule.Pattern, rule.Path)
+			}
+			return fmt.Errorf("failed to execute grep command (error code %d), stderr=%s, error=%w", exitErr.ExitCode(), stdErrBuffer.String(), err)
+		}
+		return fmt.Errorf("the grep command failed, stderr=%s, error=%w", stdErrBuffer.String(), err)
+	}
+	// exit code is zero so lines matching the pattern were detected
+	if !rule.Match {
+		return fmt.Errorf("match found for pattern %s on path %s", rule.Pattern, rule.Path)
+	}
+	return nil
+}

--- a/pkg/ruler/rules/grep_test.go
+++ b/pkg/ruler/rules/grep_test.go
@@ -1,0 +1,101 @@
+package rules_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qonto/standards-insights/pkg/project"
+	"github.com/qonto/standards-insights/pkg/ruler/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGrepRule(t *testing.T) {
+	project := project.Project{
+		Path: "./",
+	}
+
+	cases := []struct {
+		rule  rules.GrepRule
+		error string
+	}{
+		{
+			rule: rules.GrepRule{
+				Path:      "_testdata",
+				Recursive: true,
+				Pattern:   "abcdefg",
+				Match:     true,
+			},
+		},
+		{
+			rule: rules.GrepRule{
+				Path:      "_testdata",
+				Recursive: true,
+				Pattern:   "abc*",
+				Match:     true,
+			},
+		},
+		{
+			rule: rules.GrepRule{
+				Path:    "_testdata/file1",
+				Pattern: "abcdefg",
+				Match:   true,
+			},
+		},
+		{
+			rule: rules.GrepRule{
+				Path:      "_testdata",
+				Recursive: true,
+				Pattern:   "aIOJij89Yaa",
+				Match:     false,
+			},
+		},
+		{
+			rule: rules.GrepRule{
+				Path:    "_testdata/file1",
+				Pattern: "aIOJij89Yaa",
+				Match:   false,
+			},
+		},
+		{
+			rule: rules.GrepRule{
+				Path:    "_testdata",
+				Pattern: "abcdefg",
+				Match:   true,
+			},
+			error: "Is a directory",
+		},
+		{
+			rule: rules.GrepRule{
+				Path:      "_testdata",
+				Recursive: true,
+				Pattern:   "abcdefg",
+				Match:     false,
+			},
+			error: "match found for pattern",
+		},
+		{
+			rule: rules.GrepRule{
+				Path:    "_testdata/file1",
+				Pattern: "abcdefg",
+				Match:   false,
+			},
+			error: "match found for pattern",
+		},
+		{
+			rule: rules.GrepRule{
+				Path:    "_testdata/file1",
+				Pattern: "abc*",
+				Match:   false,
+			},
+			error: "match found for pattern",
+		},
+	}
+	for _, c := range cases {
+		err := c.rule.Do(context.Background(), project)
+		if c.error == "" {
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorContains(t, err, c.error)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds a new grep module that can be used to search for patterns in files or directories, recursively or not.

Users will be able to make the module fail if the pattern is found or is not found.

This module shell-out to the grep CLI because it's more convenient than reimplementing grep in pure golang.

Alpine and GolangCI lint versions are also upgraded.