### PR TITLE
Grep: add skip-not-found option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,13 @@ jobs:
           registry-type: public
           mask-password: 'true'
 
+      - name: Downgrade Helm  # 1.13.0 has bug that block push charts on OCI
+        run: |
+          curl -sSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.12.0-linux-amd64.tar.gz" && \
+          tar --strip-components=1 -C /tmp -xzvf /tmp/helm.tar.gz linux-amd64/helm && \
+          mv /tmp/helm /usr/local/bin/helm && \
+          rm -f /tmp/helm.tar.gz
+
       - name: Helm release
         run: |
           RELEASE_VERSION=$(jq -r .tag dist/metadata.json)

--- a/config/config.go
+++ b/config/config.go
@@ -45,10 +45,11 @@ type FileRule struct {
 }
 
 type GrepRule struct {
-	Path      string `validate:"required"`
-	Recursive bool
-	Pattern   string `validate:"required"`
-	Match     bool
+	Path         string `validate:"required"`
+	Recursive    bool
+	Pattern      string `validate:"required"`
+	Match        bool
+	SkipNotFound bool `yaml:"skip-not-found"`
 }
 
 type Check struct {

--- a/pkg/ruler/rules/grep_test.go
+++ b/pkg/ruler/rules/grep_test.go
@@ -28,6 +28,15 @@ func TestGrepRule(t *testing.T) {
 		},
 		{
 			rule: rules.GrepRule{
+				Path:         "_testdata",
+				Recursive:    true,
+				Pattern:      "abcdefg",
+				Match:        true,
+				SkipNotFound: true,
+			},
+		},
+		{
+			rule: rules.GrepRule{
 				Path:      "_testdata",
 				Recursive: true,
 				Pattern:   "abc*",


### PR DESCRIPTION
This option can be set to true to consider the test successful if the targeted path does not exist in the grep module.