### PR TITLE
Add logical operators to checks to chain different rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ rules:
 
 checks:
   - name: go-version-latest
+    operator: and
     labels:
       category: upgrade
       severity: critical
     rules:
       - go-version-latest
   - name: go-main
+    operator: and
     labels:
       category: code-structure
       severity: minor
@@ -71,6 +73,9 @@ Rules modules are documented in the `doc/rules` directory.
 
 We then define `checks` in the configuration. Checks are used to group similar rules together. They can also be configured with optional labels (`category` and `severity` in this example) that we will used later, when Standards Insights is run in `daemon` mode.
 In this example, the two checks contain only one rule each (`go-version-latest` and `go-main`).
+Checks supports 2 different operators to evaluate `rules`: `and` and `or`.
+`and` is the default operator and the check result will be successful if all the rules evaluate to true.
+`or` operator will mark the check as successful if at least one rule evaluates to true.
 
 Finally, we configure `groups`: groups contains checks to execute on a project when a condition is true. In this example, the group named `golang` will only be executed on projects where `golang-project` is valid (so, when the `go.mod` file exists). Thanks to the `when` condition, we can specify which check should be executed on which project.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,7 +25,6 @@ interval: 10
 providers:
   # Static list of projects to check
   static:
-  static:
     - name: "standards-insights"
       url: https://github.com/qonto/standards-insights.git
       branch: "main"
@@ -68,12 +67,14 @@ checks:
     rules:
       - go-version-latest
   - name: go-main
+    operator: and
     labels:
       category: misc
       severity: minor
       owner: backend
     rules:
       - go-main
+      - go-version-latest
   - name: grep-test
     labels:
       category: misc
@@ -90,7 +91,7 @@ rules:
   - name: go-version-latest
     files:
       - path: "go.mod"
-        contains: "go 1.20"
+        contains: "go 1.21"
   - name: go-main
     files:
       - path: "main.go"

--- a/config/config.go
+++ b/config/config.go
@@ -53,9 +53,14 @@ type GrepRule struct {
 }
 
 type Check struct {
-	Name   string `validate:"required"`
-	Labels map[string]string
-	Rules  []string `validate:"required,min=1"`
+	Name     string `validate:"required"`
+	Labels   map[string]string
+	Operator string   `validate:"oneof=and or"`
+	Rules    []string `validate:"required,min=1"`
+}
+
+func (c Check) IsAND() bool {
+	return c.Operator == "" || c.Operator == "and"
 }
 
 type Group struct {

--- a/pkg/checker/check.go
+++ b/pkg/checker/check.go
@@ -12,12 +12,21 @@ import (
 )
 
 func (c *Checker) executeCheck(ctx context.Context, check config.Check, project project.Project) aggregates.CheckResult {
+	if check.IsAND() {
+		return c.executeANDCheck(ctx, check, project)
+	} else {
+		return c.executeORCheck(ctx, check, project)
+	}
+}
+
+func (c *Checker) executeANDCheck(ctx context.Context, check config.Check, project project.Project) aggregates.CheckResult {
 	success := true
 	checkResult := aggregates.CheckResult{
 		Name:    check.Name,
 		Labels:  check.Labels,
 		Results: []ruleraggregates.RuleResult{},
 	}
+
 	for _, rule := range check.Rules {
 		ruleResult := c.ruler.Execute(ctx, rule, project)
 		if !ruleResult.Success {
@@ -25,6 +34,28 @@ func (c *Checker) executeCheck(ctx context.Context, check config.Check, project 
 			success = false
 		} else {
 			c.logger.Debug(fmt.Sprintf("rule %s successful on project %s for check %s", rule, project.Name, check.Name))
+		}
+		checkResult.Results = append(checkResult.Results, ruleResult)
+	}
+	checkResult.Success = success
+	return checkResult
+}
+
+func (c *Checker) executeORCheck(ctx context.Context, check config.Check, project project.Project) aggregates.CheckResult {
+	success := false
+	checkResult := aggregates.CheckResult{
+		Name:    check.Name,
+		Labels:  check.Labels,
+		Results: []ruleraggregates.RuleResult{},
+	}
+
+	for _, rule := range check.Rules {
+		ruleResult := c.ruler.Execute(ctx, rule, project)
+		if ruleResult.Success {
+			success = true
+			c.logger.Debug(fmt.Sprintf("rule %s successful on project %s for check %s", rule, project.Name, check.Name))
+		} else {
+			c.logger.Debug(fmt.Sprintf("rule %s failed on project %s for check %s", rule, project.Name, check.Name))
 		}
 		checkResult.Results = append(checkResult.Results, ruleResult)
 	}

--- a/pkg/checker/checker_test.go
+++ b/pkg/checker/checker_test.go
@@ -41,11 +41,19 @@ func TestRun(t *testing.T) {
 				"category": "cat2",
 			},
 		},
+		{
+			Name:     "check3",
+			Rules:    []string{"rule1", "rule2"},
+			Operator: "or",
+			Labels: map[string]string{
+				"category": "cat3",
+			},
+		},
 	}
 	groups := []config.Group{
 		{
 			Name:   "group1",
-			Checks: []string{"check1", "check2"},
+			Checks: []string{"check1", "check2", "check3"},
 			When:   []string{"rule1"},
 		},
 	}
@@ -64,11 +72,14 @@ func TestRun(t *testing.T) {
 	assert.Equal(t, results[0].Name, "project1")
 	assert.Equal(t, 1, len(results[0].Labels))
 	assert.Equal(t, "sre", results[0].Labels["team"])
-	assert.Equal(t, 2, len(results[0].CheckResults))
+	assert.Equal(t, 3, len(results[0].CheckResults))
 	assert.Equal(t, "check1", results[0].CheckResults[0].Name)
 	assert.Equal(t, "check2", results[0].CheckResults[1].Name)
+	assert.Equal(t, "check3", results[0].CheckResults[2].Name)
 	assert.Equal(t, "cat1", results[0].CheckResults[0].Labels["category"])
 	assert.Equal(t, "cat2", results[0].CheckResults[1].Labels["category"])
+	assert.Equal(t, "cat3", results[0].CheckResults[2].Labels["category"])
 	assert.True(t, results[0].CheckResults[0].Success)
 	assert.False(t, results[0].CheckResults[1].Success)
+	assert.True(t, results[0].CheckResults[2].Success)
 }


### PR DESCRIPTION
Add logical operators to chain different rules.
As of now, rules are always checked in "AND" conditions inside checks.
This PR also enables "OR" semantics for a specific check