### PR TITLE
Clone or pull projects on batch command

### DIFF
--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -46,7 +46,8 @@ func batchCmd(configPath, logLevel, logFormat *string) *cobra.Command {
 				exit(err)
 
 				for _, project := range projects {
-					cloneOrPull(git, project)
+					err := cloneOrPull(git, project)
+					exit(err)
 				}
 				fmt.Println("Done!")
 


### PR DESCRIPTION
Currently the batch sub command is not pulling the repositories when, looking at his semantics I think it should
This MR adds a clone or pull function in the main loop to pull the repositories before executing the checks, ensuring their presence.