### PR TITLE
Add project ruler

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,4 +102,35 @@ rules:
         recursive: true
         pattern: "NewGrepRule"
         match: true
-
+  - name: project-is-awesome
+    project:
+      name: awesome-project
+      match: true
+  - name: project-is-not-awesome
+    project:
+      name: non-awesome-project
+      match: false
+  - name: allowed-projects
+    project:
+      names: 
+      - awesome-project1
+      - awesome-project2
+      match: true
+  - name: excluded-projects
+    project:
+      names: 
+      - bad-project1
+      - bad-project2
+      match: false
+  - name: matching-all-labels
+    project:
+      labels: 
+        team: backend
+        language: golang
+      match: true
+  - name: excluding-all-labels
+    project:
+      names: 
+        team: backend
+        language: golang
+      match: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,6 +50,12 @@ git:
     path: /home/mcorbin/.ssh/my_ssh_private_key
     password: key-password # you can use GIT_PRIVATE_KEY_PASSWORD
 
+
+
+
+
+
+
 groups:
   - name: golang
     checks:
@@ -102,35 +108,28 @@ rules:
         recursive: true
         pattern: "NewGrepRule"
         match: true
-  - name: project-is-awesome
-    project:
-      name: awesome-project
-      match: true
-  - name: project-is-not-awesome
-    project:
-      name: non-awesome-project
-      match: false
+
   - name: allowed-projects
     project:
-      names: 
-      - awesome-project1
-      - awesome-project2
-      match: true
+      - names: 
+          - awesome-project1
+          - awesome-project2
+        match: true
   - name: excluded-projects
     project:
-      names: 
-      - bad-project1
-      - bad-project2
-      match: false
+      - names: 
+          - bad-project1
+          - bad-project2
+        match: false
   - name: matching-all-labels
     project:
-      labels: 
-        team: backend
-        language: golang
-      match: true
+      - labels: 
+          team: backend
+          language: golang
+        match: true
   - name: excluding-all-labels
     project:
-      names: 
-        team: backend
-        language: golang
-      match: false
+      - names: 
+          team: backend
+          language: golang
+        match: false

--- a/config/config.go
+++ b/config/config.go
@@ -10,17 +10,17 @@ import (
 type Config struct {
 	HTTP      HTTPConfig      `validate:"omitempty"`
 	Providers ProvidersConfig `validate:"omitempty"`
-	Groups    []Group
-	Checks    []Check
-	Rules     []Rule
-	Labels    []string
+	Groups    []Group         `validate:"dive"`
+	Checks    []Check         `validate:"dive"`
+	Rules     []Rule          `validate:"dive"`
+	Labels    []string        `validate:"dive"`
 	Interval  int
 	Git       GitConfig
 }
 
 type ProvidersConfig struct {
 	ArgoCD ArgoCDConfig      `validate:"omitempty"`
-	Static []project.Project `validate:"omitempty"`
+	Static []project.Project `validate:"omitempty,dive"`
 }
 
 type ArgoCDConfig struct {
@@ -31,10 +31,11 @@ type ArgoCDConfig struct {
 }
 
 type Rule struct {
-	Name   string `validate:"required"`
-	Files  []FileRule
-	Grep   []GrepRule
-	Simple *bool
+	Name    string     `validate:"required"`
+	Files   []FileRule `validate:"dive"`
+	Grep    []GrepRule `validate:"dive"`
+	Project ProjectRule
+	Simple  *bool
 }
 
 type FileRule struct {
@@ -52,10 +53,17 @@ type GrepRule struct {
 	SkipNotFound bool `yaml:"skip-not-found"`
 }
 
+type ProjectRule struct {
+	Name   string
+	Names  []string `validate:"excluded_with=Name"`
+	Labels map[string]string
+	Match  *bool
+}
+
 type Check struct {
 	Name     string `validate:"required"`
 	Labels   map[string]string
-	Operator string   `validate:"oneof=and or"`
+	Operator string   `validate:"oneof='and' 'or' ''"`
 	Rules    []string `validate:"required,min=1"`
 }
 
@@ -85,5 +93,6 @@ func New(path string) (*Config, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return &config, content, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,10 +31,10 @@ type ArgoCDConfig struct {
 }
 
 type Rule struct {
-	Name    string     `validate:"required"`
-	Files   []FileRule `validate:"dive"`
-	Grep    []GrepRule `validate:"dive"`
-	Project ProjectRule
+	Name    string        `validate:"required"`
+	Files   []FileRule    `validate:"dive"`
+	Grep    []GrepRule    `validate:"dive"`
+	Project []ProjectRule `validate:"dive"`
 	Simple  *bool
 }
 
@@ -54,8 +54,7 @@ type GrepRule struct {
 }
 
 type ProjectRule struct {
-	Name   string
-	Names  []string `validate:"excluded_with=Name"`
+	Names  []string
 	Labels map[string]string
 	Match  *bool
 }

--- a/pkg/ruler/builder.go
+++ b/pkg/ruler/builder.go
@@ -28,6 +28,9 @@ func newRule(config config.Rule) *rule {
 	for _, grepConfig := range config.Grep {
 		modules = append(modules, rules.NewGrepRule(grepConfig))
 	}
+
+	modules = append(modules, rules.NewProjectRule(config.Project))
+
 	if config.Simple != nil {
 		value := *config.Simple
 		modules = append(modules, rules.NewSimpleRule(value))

--- a/pkg/ruler/builder.go
+++ b/pkg/ruler/builder.go
@@ -28,8 +28,9 @@ func newRule(config config.Rule) *rule {
 	for _, grepConfig := range config.Grep {
 		modules = append(modules, rules.NewGrepRule(grepConfig))
 	}
-
-	modules = append(modules, rules.NewProjectRule(config.Project))
+	for _, projectConfig := range config.Project {
+		modules = append(modules, rules.NewProjectRule(projectConfig))
+	}
 
 	if config.Simple != nil {
 		value := *config.Simple

--- a/pkg/ruler/rules/project.go
+++ b/pkg/ruler/rules/project.go
@@ -24,15 +24,6 @@ func (rule *ProjectRule) Do(ctx context.Context, project project.Project) error 
 		match = *rule.config.Match
 	}
 
-	if rule.config.Name != "" {
-		if match && project.Name != rule.config.Name {
-			return fmt.Errorf("project name %s is not %s", project.Name, rule.config.Name)
-		}
-		if !match && project.Name == rule.config.Name {
-			return fmt.Errorf("project name %s is matching", project.Name)
-		}
-	}
-
 	if len(rule.config.Names) > 0 {
 		if match && !contains(project.Name, rule.config.Names) {
 			return fmt.Errorf("project name %s is not in %v", project.Name, rule.config.Names)

--- a/pkg/ruler/rules/project.go
+++ b/pkg/ruler/rules/project.go
@@ -1,0 +1,76 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qonto/standards-insights/config"
+	"github.com/qonto/standards-insights/pkg/project"
+)
+
+type ProjectRule struct {
+	config config.ProjectRule
+}
+
+func NewProjectRule(config config.ProjectRule) *ProjectRule {
+	return &ProjectRule{
+		config: config,
+	}
+}
+
+func (rule *ProjectRule) Do(ctx context.Context, project project.Project) error {
+	match := true
+	if rule.config.Match != nil {
+		match = *rule.config.Match
+	}
+
+	if rule.config.Name != "" {
+		if match && project.Name != rule.config.Name {
+			return fmt.Errorf("project name %s is not %s", project.Name, rule.config.Name)
+		}
+		if !match && project.Name == rule.config.Name {
+			return fmt.Errorf("project name %s is matching", project.Name)
+		}
+	}
+
+	if len(rule.config.Names) > 0 {
+		if match && !contains(project.Name, rule.config.Names) {
+			return fmt.Errorf("project name %s is not in %v", project.Name, rule.config.Names)
+		}
+		if !match && contains(project.Name, rule.config.Names) {
+			return fmt.Errorf("project name %s is matching one of %v", project.Name, rule.config.Names)
+		}
+	}
+
+	if len(rule.config.Labels) > 0 {
+		if match && !isSubset(rule.config.Labels, project.Labels) {
+			return fmt.Errorf("project labels %v does not contain %v", project.Labels, rule.config.Labels)
+		}
+		if !match && isSubset(rule.config.Labels, project.Labels) {
+			return fmt.Errorf("project labels %v contain %v", project.Labels, rule.config.Labels)
+		}
+	}
+
+	return nil
+}
+
+func isSubset(a, b map[string]string) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for k, vsub := range a {
+		if vm, found := b[k]; !found || vm != vsub {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s string, slice []string) bool {
+	for _, v := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ruler/rules/project_test.go
+++ b/pkg/ruler/rules/project_test.go
@@ -25,41 +25,6 @@ func TestProjectRule_Do(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "project name match",
-			config: config.ProjectRule{
-				Name: "a",
-			},
-			project: project.Project{Name: "a"},
-			wantErr: nil,
-		},
-		{
-			name: "project name does not match",
-			config: config.ProjectRule{
-				Name: "a",
-			},
-			project: project.Project{Name: "c"},
-			wantErr: errors.New("project name c is not a"),
-		},
-		{
-			name: "project name matches and should not",
-			config: config.ProjectRule{
-				Name:  "a",
-				Match: &f,
-			},
-			project: project.Project{Name: "a"},
-			wantErr: errors.New("project name a is matching"),
-		},
-		{
-			name: "project name does not match and should not",
-			config: config.ProjectRule{
-				Name:  "a",
-				Match: &f,
-			},
-			project: project.Project{Name: "c"},
-			wantErr: nil,
-		},
-
-		{
 			name: "project name list match",
 			config: config.ProjectRule{
 				Names: []string{"a", "b", "c"},

--- a/pkg/ruler/rules/project_test.go
+++ b/pkg/ruler/rules/project_test.go
@@ -1,0 +1,167 @@
+package rules
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qonto/standards-insights/config"
+	"github.com/qonto/standards-insights/pkg/project"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectRule_Do(t *testing.T) {
+	f := false
+	tests := []struct {
+		name    string
+		config  config.ProjectRule
+		project project.Project
+		wantErr error
+	}{
+		{
+			name:    "empty rule should pass",
+			config:  config.ProjectRule{},
+			project: project.Project{Name: "a", Labels: map[string]string{"a": "b"}},
+			wantErr: nil,
+		},
+		{
+			name: "project name match",
+			config: config.ProjectRule{
+				Name: "a",
+			},
+			project: project.Project{Name: "a"},
+			wantErr: nil,
+		},
+		{
+			name: "project name does not match",
+			config: config.ProjectRule{
+				Name: "a",
+			},
+			project: project.Project{Name: "c"},
+			wantErr: errors.New("project name c is not a"),
+		},
+		{
+			name: "project name matches and should not",
+			config: config.ProjectRule{
+				Name:  "a",
+				Match: &f,
+			},
+			project: project.Project{Name: "a"},
+			wantErr: errors.New("project name a is matching"),
+		},
+		{
+			name: "project name does not match and should not",
+			config: config.ProjectRule{
+				Name:  "a",
+				Match: &f,
+			},
+			project: project.Project{Name: "c"},
+			wantErr: nil,
+		},
+
+		{
+			name: "project name list match",
+			config: config.ProjectRule{
+				Names: []string{"a", "b", "c"},
+			},
+			project: project.Project{Name: "b"},
+			wantErr: nil,
+		},
+		{
+			name: "project name does not match list",
+			config: config.ProjectRule{
+				Names: []string{"a", "b", "c"},
+			},
+			project: project.Project{Name: "f"},
+			wantErr: errors.New("project name f is not in [a b c]"),
+		},
+		{
+			name: "project name matches list and should not",
+			config: config.ProjectRule{
+				Names: []string{"a", "b", "c"},
+				Match: &f,
+			},
+			project: project.Project{Name: "a"},
+			wantErr: errors.New("project name a is matching one of [a b c]"),
+		},
+		{
+			name: "project name does not match list and should not",
+			config: config.ProjectRule{
+				Names: []string{"a", "b", "c"},
+				Match: &f,
+			},
+			project: project.Project{Name: "e"},
+			wantErr: nil,
+		},
+
+		{
+			name: "project labels full match",
+			config: config.ProjectRule{
+				Labels: map[string]string{
+					"a": "b",
+					"e": "f",
+				},
+			},
+			project: project.Project{Labels: map[string]string{
+				"a": "b",
+				"c": "d",
+				"e": "f",
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "project labels not matching",
+			config: config.ProjectRule{
+				Labels: map[string]string{
+					"a": "b",
+					"e": "f",
+				},
+			},
+			project: project.Project{Labels: map[string]string{
+				"a": "b",
+				"c": "d",
+				"g": "h",
+			}},
+			wantErr: errors.New("project labels map[a:b c:d g:h] does not contain map[a:b e:f]"),
+		},
+		{
+			name: "project labels should not match",
+			config: config.ProjectRule{
+				Labels: map[string]string{
+					"a": "b",
+					"e": "f",
+				},
+				Match: &f,
+			},
+			project: project.Project{Labels: map[string]string{
+				"a": "b",
+				"c": "d",
+				"e": "f",
+			}},
+			wantErr: errors.New("project labels map[a:b c:d e:f] contain map[a:b e:f]"),
+		},
+		{
+			name: "project labels should not match and don't match",
+			config: config.ProjectRule{
+				Labels: map[string]string{
+					"a": "b",
+					"e": "h",
+				},
+				Match: &f,
+			},
+			project: project.Project{Labels: map[string]string{
+				"a": "b",
+				"c": "d",
+				"e": "f",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewProjectRule(tt.config)
+
+			err := rule.Do(context.Background(), tt.project)
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Add project ruler in order to be able to have matches based on project name or project labels.
This can be useful to select (or filter) groups from providers based on project name or project labels.
an example of this can be:

```yaml
  # will evaluate to true if project name is matching one of the names in the list
  - name: allowed-projects
    project:
      - names: 
          - awesome-project1
          - awesome-project2
        match: true

  # will evaluate to true if project name is matching none of the names in the list
  - name: excluded-projects
    project:
      - names: 
          - bad-project1
          - bad-project2
        match: false

  # will evaluate to true if project labels are a superset of the listed labels
  - name: matching-all-labels
    project:
      - labels: 
          team: backend
          language: golang
        match: true

  # will evaluate to true if all listed labels are not a subset of the project labels
  - name: excluding-all-labels
    project:
      - names: 
          team: backend
          language: golang
        match: false
```

the project rule is implemented as an array so it will be easy to compose different evaluations in the same rule with an AND logic:

```yaml
  - name: allowed-projects
    project:
      - names: 
          - awesome-project1
          - awesome-project2
        match: true
      - names:
          - bad-project
        match: false
```

I also took the chance to add `validate:"dive"` in order to cascade validation checks also to slice elements