### PR TITLE
Improve gitlab provider label generation

### DIFF
--- a/internal/providers/gitlab/root.go
+++ b/internal/providers/gitlab/root.go
@@ -104,9 +104,16 @@ func (c *Client) makeProjects(projects []*gitlab.Project) []project.Project {
 	for i, proj := range projects {
 		labels := make(map[string]string)
 		for _, topic := range proj.Topics {
-			if split := strings.Split(topic, ": "); len(split) > 1 {
-				labels[split[0]] = split[1]
+			split := strings.Split(topic, ":")
+
+			key := strings.Trim(split[0], " ")
+			if len(split) == 1 {
+				labels[key] = "true"
+				continue
 			}
+
+			value := strings.Trim(split[1], " ")
+			labels[key] = value
 		}
 
 		result[i] = project.Project{


### PR DESCRIPTION
Improve gitlab provider label generations to better handle values:
- Export topics that have no `:` inside as a label with value true
- trim content

in the following example
![Screenshot 2024-01-26 at 17 04 46](https://github.com/qonto/standards-insights/assets/1444986/a2c263a5-85a5-4ec5-a43b-67d11abf4251)
the labels exported will be:
```yaml
labels:
  internal: true
  go-lib: true
  team: local-payments
```