### PR TITLE
Ignore pending deletion Gitlab projects

### DIFF
--- a/internal/providers/gitlab/root.go
+++ b/internal/providers/gitlab/root.go
@@ -65,6 +65,7 @@ func makeGitlabListProjectsOptions(config config.GitlabConfig) *gitlab.ListProje
 			PerPage: 25,
 			Sort:    "asc",
 		},
+		IncludePendingDelete: gitlab.Ptr(false),
 	}
 
 	if len(config.Topics) > 0 {


### PR DESCRIPTION
## Objective

This MR aims to ignore pending deletion projects when fetched from Gitlab.