### PR TITLE
Improve run command output

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/qonto/standards-insights/pkg/checker/aggregates"
 )
@@ -11,10 +12,18 @@ func stdoutResults(results []aggregates.ProjectResult) {
 		fmt.Printf("== Project %s\n", project.Name)
 		for _, result := range project.CheckResults {
 			if result.Success {
-				fmt.Printf("✅ Check %s PASS (labels: %s)\n", result.Name, result.Labels)
+				fmt.Printf("✅ Check %s PASS\n", result.Name)
+				for key, value := range result.Labels {
+					fmt.Printf("\t%s: %s\n", key, value)
+				}
 			} else {
-				fmt.Printf("🚨 Check %s FAILED (labels: %s)\n", result.Name, result.Labels)
-				fmt.Printf("🚨 %+v\n", result)
+				fmt.Printf("🚨 Check %s FAILED\n", result.Name)
+				for key, value := range result.Labels {
+					fmt.Printf("\t%s: %s\n", key, value)
+				}
+				for _, ruleResult := range result.Results {
+					fmt.Printf("\tMessage: %s\n", strings.Join(ruleResult.Messages, ","))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Run command was too much verbose (we can't click on links, etc.)

Now it can be easily read from:

```bash
== Project standards-insights
🚨 Check go-version-latest FAILED
	category: upgrade
	runbook_url: XXXX
	severity: critical
	Message: pattern go 1.22 not found in file go.mod
✅ Check go-deprecated-libs PASS
	category: libraries
	runbook_url: XXX
	severity: major
🚨 Check renovate-bot FAILED
	category: libraries
	level: gold
	runbook_url: XXXX
	severity: minor
	Message: file renovate.json does not exist
```