### PR TITLE
Log rules errors as error

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -47,6 +47,9 @@ func (r *Ruler) Execute(ctx context.Context, ruleName string, project project.Pr
 		}
 	}
 	if len(errorMessages) > 0 {
+		for _, errorMessage := range errorMessages {
+			r.logger.Error(fmt.Sprintf("error on rule %s for project %s: %s", ruleName, project.Name, errorMessage))
+		}
 		return aggregates.RuleResult{
 			Success:  false,
 			RuleName: ruleName,


### PR DESCRIPTION
When a rule fails, we want to know why to facilitate investigations.