### PR TITLE
Add support for extended regexp in grep rule

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,12 +55,13 @@ type FileRule struct {
 }
 
 type GrepRule struct {
-	Path         string `validate:"required"`
-	Pattern      string `validate:"required"`
-	Include      string
-	Recursive    bool
-	Match        bool
-	SkipNotFound bool `yaml:"skip-not-found"`
+	Path           string `validate:"required"`
+	Pattern        string `validate:"required"`
+	Include        string
+	ExtendedRegexp bool `yaml:"extended-regexp"`
+	Recursive      bool
+	Match          bool
+	SkipNotFound   bool `yaml:"skip-not-found"`
 }
 
 type ProjectRule struct {

--- a/doc/rules/grep.md
+++ b/doc/rules/grep.md
@@ -19,5 +19,6 @@ Available options are:
 
 - `path`: the file or directory to check (mandatory)
 - `pattern`: the string pattern to search for (mandatory)
-- `recursive`: recursively search subdirectories listed (grep `-r`option)
-- `match`: if set to true, the module will be successful if the pattern is found. Default to false, where the module will be successful if the pattern is **not** found.
+- `recursive`: recursively search subdirectories listed (grep `-r` option)
+- `match`: if set to true, the module will be successful if the pattern is found. Default to false, where the module will be successful if the pattern is **not** found
+- `extended-regexp`: if set to true, the pattern is treated as an extended regular expression (grep `-E` option)

--- a/pkg/ruler/rules/grep.go
+++ b/pkg/ruler/rules/grep.go
@@ -14,22 +14,24 @@ import (
 )
 
 type GrepRule struct {
-	Path         string
-	Include      string
-	Pattern      string
-	Recursive    bool
-	Match        bool
-	SkipNotFound bool
+	Path           string
+	Include        string
+	Pattern        string
+	ExtendedRegexp bool
+	Recursive      bool
+	Match          bool
+	SkipNotFound   bool
 }
 
 func NewGrepRule(config config.GrepRule) *GrepRule {
 	return &GrepRule{
-		Path:         config.Path,
-		Recursive:    config.Recursive,
-		Pattern:      config.Pattern,
-		Include:      config.Include,
-		Match:        config.Match,
-		SkipNotFound: config.SkipNotFound,
+		Path:           config.Path,
+		Recursive:      config.Recursive,
+		Pattern:        config.Pattern,
+		ExtendedRegexp: config.ExtendedRegexp,
+		Include:        config.Include,
+		Match:          config.Match,
+		SkipNotFound:   config.SkipNotFound,
 	}
 }
 
@@ -46,6 +48,9 @@ func (rule *GrepRule) Do(ctx context.Context, project project.Project) error {
 	}
 	if rule.Include != "" {
 		arguments = append(arguments, "--include", rule.Include)
+	}
+	if rule.ExtendedRegexp {
+		arguments = append(arguments, "--extended-regexp")
 	}
 	arguments = append(arguments, rule.Pattern, path)
 

--- a/pkg/ruler/rules/grep_test.go
+++ b/pkg/ruler/rules/grep_test.go
@@ -83,6 +83,27 @@ func TestGrepRule(t *testing.T) {
 		},
 		{
 			rule: rules.GrepRule{
+				Path:           "_testdata",
+				Recursive:      true,
+				Include:        "file1",
+				Pattern:        "abc?defg",
+				ExtendedRegexp: false,
+				Match:          true,
+			},
+			error: "no match for pattern",
+		},
+		{
+			rule: rules.GrepRule{
+				Path:           "_testdata",
+				Recursive:      true,
+				Include:        "file1",
+				Pattern:        "abc?defg",
+				ExtendedRegexp: true,
+				Match:          true,
+			},
+		},
+		{
+			rule: rules.GrepRule{
 				Path:      "_testdata",
 				Recursive: true,
 				Include:   "file2",


### PR DESCRIPTION
The `grep` rule is using the default behaviour of `grep` to match the pattern. This default is using [the "basic regular expression"][1], which can be less powerful in some cases. For instance, `abc?` won’t match `ab`.

To solve this, `grep` command accepts a [`--extended-regexp` flag][2], which this patch is adding to the `grep` rule.

[1]: https://man7.org/linux/man-pages/man1/grep.1.html#REGULAR_EXPRESSIONS
[2]: https://man7.org/linux/man-pages/man1/grep.1.html#OPTIONS