### PR TITLE
Add support for null-data (-z flag) in grep rule

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type GrepRule struct {
 	Recursive      bool
 	Match          bool
 	SkipNotFound   bool `yaml:"skip-not-found"`
+	NullData       bool `yaml:"null-data"`
 }
 
 type ProjectRule struct {

--- a/doc/rules/grep.md
+++ b/doc/rules/grep.md
@@ -22,3 +22,4 @@ Available options are:
 - `recursive`: recursively search subdirectories listed (grep `-r` option)
 - `match`: if set to true, the module will be successful if the pattern is found. Default to false, where the module will be successful if the pattern is **not** found
 - `extended-regexp`: if set to true, the pattern is treated as an extended regular expression (grep `-E` option)
+- `null-data`: if set to true, treat input data as sequences of lines terminated by a zero-byte instead of a newline. Useful with multi-line matching. (grep `-z` option)

--- a/pkg/ruler/rules/_testdata/file1
+++ b/pkg/ruler/rules/_testdata/file1
@@ -1,3 +1,4 @@
 abcdefg
 <3_ruby
 azerty
+    <3_go

--- a/pkg/ruler/rules/grep.go
+++ b/pkg/ruler/rules/grep.go
@@ -21,6 +21,7 @@ type GrepRule struct {
 	Recursive      bool
 	Match          bool
 	SkipNotFound   bool
+	NullData       bool
 }
 
 func NewGrepRule(config config.GrepRule) *GrepRule {
@@ -32,6 +33,7 @@ func NewGrepRule(config config.GrepRule) *GrepRule {
 		Include:        config.Include,
 		Match:          config.Match,
 		SkipNotFound:   config.SkipNotFound,
+		NullData:       config.NullData,
 	}
 }
 
@@ -51,6 +53,9 @@ func (rule *GrepRule) Do(ctx context.Context, project project.Project) error {
 	}
 	if rule.ExtendedRegexp {
 		arguments = append(arguments, "--extended-regexp")
+	}
+	if rule.NullData {
+		arguments = append(arguments, "-z")
 	}
 	arguments = append(arguments, rule.Pattern, path)
 

--- a/pkg/ruler/rules/grep_test.go
+++ b/pkg/ruler/rules/grep_test.go
@@ -145,6 +145,29 @@ func TestGrepRule(t *testing.T) {
 			},
 			error: "match found for pattern",
 		},
+		{
+			rule: rules.GrepRule{
+				Path:           "_testdata",
+				Recursive:      true,
+				Include:        "file1",
+				Pattern:        "azerty.*[[:space:]]+<3_go",
+				ExtendedRegexp: true,
+				Match:          true,
+				NullData:       false,
+			},
+			error: "no match for pattern",
+		},
+		{
+			rule: rules.GrepRule{
+				Path:           "_testdata",
+				Recursive:      true,
+				Include:        "file1",
+				Pattern:        "azerty.*[[:space:]]+<3_go",
+				ExtendedRegexp: true,
+				Match:          true,
+				NullData:       true,
+			},
+		},
 	}
 	for _, c := range cases {
 		err := c.rule.Do(context.Background(), project)


### PR DESCRIPTION
It should facilitate **multi-lines matching** on **yaml** files since it treats the input as a set of lines each terminated with a zero byte instead of newline.

In other words, `grep` sees the input as **one big line**.

**_example_**: with the -z flag (or --null-data), you cloud match this pattern
```red
toto:
  tata:
```
inside this file:
```yaml
# test.yaml
titi:
  toto:
    tata:
```