### PR TITLE
use github.com/dlclark/regexp2 isntead of standard regex

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.3
 
 require (
+	github.com/dlclark/regexp2 v1.11.5
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-playground/validator/v10 v10.22.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/pkg/ruler/rules/file.go
+++ b/pkg/ruler/rules/file.go
@@ -40,8 +40,12 @@ func (rule *FileRule) Do(ctx context.Context, project project.Project) error {
 		scanner := bufio.NewScanner(file)
 
 		for scanner.Scan() {
-			line := scanner.Bytes()
-			if rule.Contains.Regexp.Match(line) {
+			line := scanner.Text()
+			matched, err := rule.Contains.Regexp.MatchString(line)
+			if err != nil {
+				return fmt.Errorf("error while reading file %s: %w", rule.Path, err)
+			}
+			if matched {
 				return nil
 			}
 		}
@@ -62,8 +66,12 @@ func (rule *FileRule) Do(ctx context.Context, project project.Project) error {
 		scanner := bufio.NewScanner(file)
 
 		for scanner.Scan() {
-			line := scanner.Bytes()
-			if rule.NotContains.Regexp.Match(line) {
+			line := scanner.Text()
+			matched, err := rule.NotContains.Regexp.MatchString(line)
+			if err != nil {
+				return fmt.Errorf("error while reading file %s: %w", rule.Path, err)
+			}
+			if matched {
 				return fmt.Errorf("pattern %s found in file %s", rule.NotContains, rule.Path)
 			}
 		}

--- a/types/regexp.go
+++ b/types/regexp.go
@@ -1,13 +1,15 @@
 package types
 
-import "regexp"
+import (
+	"github.com/dlclark/regexp2"
+)
 
 type Regexp struct {
-	*regexp.Regexp
+	*regexp2.Regexp
 }
 
 func RegexpFromString(pattern string) (*Regexp, error) {
-	regexp, err := regexp.Compile(pattern)
+	regexp, err := regexp2.Compile(pattern, regexp2.DefaultUnmarshalOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -18,7 +20,7 @@ func RegexpFromString(pattern string) (*Regexp, error) {
 
 // UnmarshalText unmarshals json into a regexp.Regexp
 func (r *Regexp) UnmarshalText(b []byte) error {
-	regex, err := regexp.Compile(string(b))
+	regex, err := regexp2.Compile(string(b), regexp2.DefaultUnmarshalOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR aims to allow usage of backtracking regexes in the files rules by migrating from default go `regexp` to https://github.com/dlclark/regexp2

