### PR TITLE
Add debug logs for generation of the GitHub token

### DIFF
--- a/internal/providers/github/root.go
+++ b/internal/providers/github/root.go
@@ -160,7 +160,8 @@ func (c *Client) ConfigureGit(g daemon.Git) error {
 
 	token, err := itr.Token(context.Background())
 	if err != nil {
-		return err
+		c.logger.Error("failed to generate GitHub installation token", "error", err)
+		return fmt.Errorf("failed to generate GitHub installation token: %w", err)
 	}
 
 	g.SetToken(token)


### PR DESCRIPTION
We sometimes fail to clone some GitHub repositories. This commit is adding some logs to troubleshoot what is happenning.