### PR TITLE
Fix finding CODEOWNERS

### DIFF
--- a/pkg/codeowners/codeowners.go
+++ b/pkg/codeowners/codeowners.go
@@ -16,7 +16,7 @@ func NewCodeowners(path string, configPath string) (*Codeowners, error) {
 	// open filesystem rooted at current working directory
 	fsys := os.DirFS(path)
 
-	c, err := codeowners.FromFileWithFS(fsys, "CODEOWNERS")
+	c, err := codeowners.FromFileWithFS(fsys, ".")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codeowners/codeowners_test.go
+++ b/pkg/codeowners/codeowners_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestNewCodeowners_FromFileWithFS(t *testing.T) {
+	// Create temp dir with CODEOWNERS file
+	tmpDir := t.TempDir()
+	err := os.WriteFile(tmpDir+"/CODEOWNERS", []byte("* @test"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create CODEOWNERS: %v", err)
+	}
+
+	co, err := NewCodeowners(tmpDir, "")
+	if err != nil {
+		t.Errorf("NewCodeowners failed: %v)", err)
+	}
+	owner, _ := co.GetOwners("*")
+	if owner != "@test" {
+		t.Errorf("GetOwners() for path %s, expected owner %s, but got %s", "*", "@test", owner)
+	}
+}
+
 func TestCodeowners_FromFile(t *testing.T) {
 	// Ensure the CODEOWNERS file exists
 	if _, err := os.Stat(".gitlab/CODEOWNERS"); os.IsNotExist(err) {


### PR DESCRIPTION
The second argument to [`codeowners.FromFileWithFS`][1] is the path where we look for a CODEOWNERS file, no the name of the file.

[1]: https://github.com/hairyhenderson/go-codeowners/blob/v0.5.0/codeowners.go#L103