### PR TITLE
Assign team to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Create a new `config.yaml` file containing:
 ```yaml
 interval: 30
 
+labels:
+  - team
+
 rules:
   - name: golang-project
     files:

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -156,6 +156,14 @@ func (d *Daemon) tick(configPath string) {
 			codeowners, err := codeowners.NewCodeowners(proj.Path, configPath)
 			if err != nil {
 				d.logger.Warn(fmt.Sprintf("Failed to parse CODEOWNERS for project %s: %s", proj.Name, err.Error()))
+			} else {
+				// Assign team to root project from CODEOWNERS
+				if team, exists := codeowners.GetOwners("."); exists {
+					if proj.Labels == nil {
+						proj.Labels = make(map[string]string)
+					}
+					proj.Labels["team"] = team
+				}
 			}
 			// Create subprojects based on expanded paths
 			err = d.exploreProjectFiles(proj.Path, codeowners, proj, &subProjects)


### PR DESCRIPTION
This patch is adding the team to the project, so that it can be reported in prometheus metrics.

For the team to be exposed, you need to add this to your configuration:
```
labels:
  - team
```