### PR TITLE
Reset Prometheus gauge between each ticks

### DIFF
--- a/internal/metrics/project.go
+++ b/internal/metrics/project.go
@@ -31,6 +31,7 @@ func New(registry *prometheus.Registry, extraLabels []string) (*Project, error) 
 }
 
 func (p *Project) Load(results []aggregates.ProjectResult) {
+	p.checksGauge.Reset()
 	for _, project := range results {
 		projectLabels := project.Labels
 		for _, result := range project.CheckResults {


### PR DESCRIPTION
When changing a team, we had duplicated metrics: one with the old team name, and one with the new team name.

This is because the `Load()` method in only setting / updating metrics, but its not clearing the old ones. This patch is adding a `Reset()` at the beginning to ensure clearing of stale data.