### PR TITLE
feat: allow repositories to skip checks/groups via .standards-insights.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,26 @@ check_result_success{category="upgrade",name="go-version-latest",project="standa
 
 Both checks were successful, so the value of the metric is `1`. In case of failure, the value would be `0`.
 
+### Per-repository skip configuration
+
+A repository can opt out of specific checks and/or groups by committing a
+`.standards-insights.yaml` file to its root, similar to disabling a rule in a `.rubocop.yml`.
+This lets repository owners suppress irrelevant or intentionally-non-compliant checks without
+changing the central configuration.
+
+```yaml
+# .standards-insights.yaml (at the root of the checked repository)
+skip:
+  groups:
+    - golang            # skips every check in the "golang" group
+  checks:
+    - go-version-latest # skips this check wherever it runs
+```
+
+- Both `groups` and `checks` are optional; you can provide either or both.
+- Names must match the group/check names configured in Standards Insights. Unknown names are
+  logged as warnings.
+- Skipped checks are not executed and produce no Prometheus metric for that repository.
+- The file fails open: if it is missing nothing is skipped, and if it is malformed a warning is
+  logged and all checks still run.
+

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,6 +62,15 @@ git:
 
 
 
+# A checked repository can opt out of specific checks and/or groups by committing a
+# `.standards-insights.yaml` file to its root (similar to a `.rubocop.yml`):
+#
+#   skip:
+#     groups:
+#       - golang            # skips every check in the "golang" group
+#     checks:
+#       - go-version-latest # skips this check wherever it runs
+
 groups:
   - name: golang
     checks:

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -41,17 +41,26 @@ func (c *Checker) Run(ctx context.Context, projects []project.Project) []aggrega
 	projectResults := make([]aggregates.ProjectResult, 0)
 	for _, project := range projects {
 		c.logger.Info("checking project " + project.Name)
+		skippedGroups, skippedChecks, err := loadSkipConfig(project.Path)
+		if err != nil {
+			c.logger.Warn(fmt.Sprintf("ignoring malformed %s for project %s: %v", skipConfigFileName, project.Name, err))
+		}
+		c.warnUnknownSkips(project, skippedGroups, skippedChecks)
 		projectResult := aggregates.ProjectResult{
 			Labels:       project.Labels,
 			Name:         project.Name,
 			CheckResults: []aggregates.CheckResult{},
 		}
 		for _, group := range c.groups {
+			if skippedGroups[group.Name] {
+				c.logger.Debug(fmt.Sprintf("group %s skipped by %s for project %s", group.Name, skipConfigFileName, project.Name))
+				continue
+			}
 			if c.shouldSkipGroup(ctx, group, project) {
 				c.logger.Debug(fmt.Sprintf("skipping group %s for project %s", group.Name, project.Name))
 				continue
 			}
-			checkResults := c.executeGroup(ctx, group, project)
+			checkResults := c.executeGroup(ctx, group, project, skippedChecks)
 			projectResult.CheckResults = append(projectResult.CheckResults, checkResults...)
 
 			if group.Files.ApplyToFiles {
@@ -70,7 +79,7 @@ func (c *Checker) Run(ctx context.Context, projects []project.Project) []aggrega
 						FilePath:     subProject.FilePath,
 						CheckResults: []aggregates.CheckResult{},
 					}
-					subProjectCheckResults := c.executeGroup(ctx, group, subProject)
+					subProjectCheckResults := c.executeGroup(ctx, group, subProject, skippedChecks)
 					subProjectResult.CheckResults = append(subProjectResult.CheckResults, subProjectCheckResults...)
 					projectResults = append(projectResults, subProjectResult)
 				}

--- a/pkg/checker/checker_test.go
+++ b/pkg/checker/checker_test.go
@@ -3,6 +3,8 @@ package checker_test
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/qonto/standards-insights/config"
@@ -10,6 +12,7 @@ import (
 	"github.com/qonto/standards-insights/pkg/project"
 	"github.com/qonto/standards-insights/pkg/ruler"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {
@@ -82,4 +85,41 @@ func TestRun(t *testing.T) {
 	assert.True(t, results[0].CheckResults[0].Success)
 	assert.False(t, results[0].CheckResults[1].Success)
 	assert.True(t, results[0].CheckResults[2].Success)
+}
+
+func TestRunWithSkipConfig(t *testing.T) {
+	yes := true
+	logger := slog.Default()
+	r := ruler.NewRuler(logger, []config.Rule{
+		{Name: "rule1", Simple: &yes},
+	})
+	checks := []config.Check{
+		{Name: "check1", Rules: []string{"rule1"}},
+		{Name: "check2", Rules: []string{"rule1"}},
+		{Name: "check3", Rules: []string{"rule1"}},
+	}
+	groups := []config.Group{
+		{Name: "group1", Checks: []string{"check1", "check2"}},
+		{Name: "group2", Checks: []string{"check3"}},
+	}
+	c := checker.NewChecker(logger, r, checks, groups)
+
+	// Repo opts out of check1 (individual) and group2 (whole group).
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ".standards-insights.yaml"), []byte(`
+skip:
+  groups:
+    - group2
+  checks:
+    - check1
+`), 0o600)
+	require.NoError(t, err)
+
+	projects := []project.Project{{Name: "project1", Path: dir}}
+	results := c.Run(context.Background(), projects)
+
+	require.Equal(t, 1, len(results))
+	// check1 (skipped) and check3 (group2 skipped) are gone; only check2 remains.
+	require.Equal(t, 1, len(results[0].CheckResults))
+	assert.Equal(t, "check2", results[0].CheckResults[0].Name)
 }

--- a/pkg/checker/group.go
+++ b/pkg/checker/group.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/qonto/standards-insights/config"
 	"github.com/qonto/standards-insights/pkg/checker/aggregates"
@@ -18,9 +19,13 @@ func (c *Checker) shouldSkipGroup(ctx context.Context, group config.Group, proje
 	return false
 }
 
-func (c *Checker) executeGroup(ctx context.Context, group config.Group, project project.Project) []aggregates.CheckResult {
+func (c *Checker) executeGroup(ctx context.Context, group config.Group, project project.Project, skippedChecks map[string]bool) []aggregates.CheckResult {
 	result := []aggregates.CheckResult{}
 	for _, checkName := range group.Checks {
+		if skippedChecks[checkName] {
+			c.logger.Debug(fmt.Sprintf("check %s skipped by %s for project %s", checkName, skipConfigFileName, project.Name))
+			continue
+		}
 		// For now let's consider that we checked when the config is built
 		// that checks always exist
 		check := c.checks[checkName]

--- a/pkg/checker/skipconfig.go
+++ b/pkg/checker/skipconfig.go
@@ -1,0 +1,76 @@
+package checker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/qonto/standards-insights/pkg/project"
+	"gopkg.in/yaml.v3"
+)
+
+// skipConfigFileName is the name of the optional file a repository can commit to
+// its root to opt out of specific checks and/or groups (Rubocop-style).
+const skipConfigFileName = ".standards-insights.yaml"
+
+type skipConfig struct {
+	Skip struct {
+		Groups []string `yaml:"groups"`
+		Checks []string `yaml:"checks"`
+	} `yaml:"skip"`
+}
+
+// loadSkipConfig reads the per-repository skip configuration from the root of the
+// given project path. It returns two sets (group names and check names to skip).
+//
+// It fails open: when the file is absent it returns empty sets and a nil error, and
+// when the file is malformed it returns empty sets alongside the parse error so the
+// caller can warn and skip nothing (a broken opt-out file must never silently disable
+// enforcement).
+func loadSkipConfig(projectPath string) (skippedGroups, skippedChecks map[string]bool, err error) {
+	skippedGroups = map[string]bool{}
+	skippedChecks = map[string]bool{}
+
+	path := filepath.Join(projectPath, skipConfigFileName)
+	content, err := os.ReadFile(path) //nolint
+	if err != nil {
+		if os.IsNotExist(err) {
+			return skippedGroups, skippedChecks, nil
+		}
+		return skippedGroups, skippedChecks, fmt.Errorf("failed to read %s: %w", skipConfigFileName, err)
+	}
+
+	var config skipConfig
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return skippedGroups, skippedChecks, fmt.Errorf("failed to parse %s: %w", skipConfigFileName, err)
+	}
+
+	for _, group := range config.Skip.Groups {
+		skippedGroups[group] = true
+	}
+	for _, check := range config.Skip.Checks {
+		skippedChecks[check] = true
+	}
+
+	return skippedGroups, skippedChecks, nil
+}
+
+// warnUnknownSkips logs a warning for any skipped group or check name that does not
+// match a configured group/check, to help repository owners catch typos in their
+// per-repository skip file.
+func (c *Checker) warnUnknownSkips(project project.Project, skippedGroups, skippedChecks map[string]bool) {
+	knownGroups := make(map[string]bool, len(c.groups))
+	for _, group := range c.groups {
+		knownGroups[group.Name] = true
+	}
+	for group := range skippedGroups {
+		if !knownGroups[group] {
+			c.logger.Warn(fmt.Sprintf("%s for project %s skips unknown group %s", skipConfigFileName, project.Name, group))
+		}
+	}
+	for check := range skippedChecks {
+		if _, ok := c.checks[check]; !ok {
+			c.logger.Warn(fmt.Sprintf("%s for project %s skips unknown check %s", skipConfigFileName, project.Name, check))
+		}
+	}
+}

--- a/pkg/checker/skipconfig_test.go
+++ b/pkg/checker/skipconfig_test.go
@@ -1,0 +1,73 @@
+package checker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSkipFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, skipConfigFileName), []byte(content), 0o600)
+	require.NoError(t, err)
+	return dir
+}
+
+func TestLoadSkipConfigMissingFile(t *testing.T) {
+	groups, checks, err := loadSkipConfig(t.TempDir())
+	assert.NoError(t, err)
+	assert.Empty(t, groups)
+	assert.Empty(t, checks)
+}
+
+func TestLoadSkipConfigGroupsAndChecks(t *testing.T) {
+	dir := writeSkipFile(t, `
+skip:
+  groups:
+    - golang
+  checks:
+    - go-version-latest
+    - go-main
+`)
+	groups, checks, err := loadSkipConfig(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"golang": true}, groups)
+	assert.Equal(t, map[string]bool{"go-version-latest": true, "go-main": true}, checks)
+}
+
+func TestLoadSkipConfigOnlyChecks(t *testing.T) {
+	dir := writeSkipFile(t, `
+skip:
+  checks:
+    - go-version-latest
+`)
+	groups, checks, err := loadSkipConfig(dir)
+	assert.NoError(t, err)
+	assert.Empty(t, groups)
+	assert.Equal(t, map[string]bool{"go-version-latest": true}, checks)
+}
+
+func TestLoadSkipConfigOnlyGroups(t *testing.T) {
+	dir := writeSkipFile(t, `
+skip:
+  groups:
+    - golang
+`)
+	groups, checks, err := loadSkipConfig(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"golang": true}, groups)
+	assert.Empty(t, checks)
+}
+
+func TestLoadSkipConfigMalformed(t *testing.T) {
+	dir := writeSkipFile(t, "skip: [this is not valid: yaml")
+	groups, checks, err := loadSkipConfig(dir)
+	assert.Error(t, err)
+	// Fails open: nothing is skipped when the file cannot be parsed.
+	assert.Empty(t, groups)
+	assert.Empty(t, checks)
+}


### PR DESCRIPTION
## What

Adds a **Rubocop-style, self-service opt-out**: a repository can skip specific checks and/or groups by committing a `.standards-insights.yaml` file to its root.

```yaml
# .standards-insights.yaml (at the root of the checked repository)
skip:
  groups:
    - golang            # skips every check in the "golang" group
  checks:
    - go-version-latest # skips this check wherever it runs
```

## Why

Today the checker runs every applicable check on every project — the only filters (`when` clauses, `project` name/label rules) live in the tool's central config and are group-granularity. There was no way for a repository to opt out of an irrelevant or intentionally-non-compliant check on its own, analogous to disabling a Rubocop rule in a `.rubocop.yml`.

## How

- **`pkg/checker/skipconfig.go`** (new) — `loadSkipConfig(projectPath)` reads `.standards-insights.yaml` from the repo root and returns the sets of skipped groups/checks. `warnUnknownSkips` logs a warning for names that don't match any configured group/check (catches typos).
- **`pkg/checker/checker.go`** — loads the skip config once per project, skips named groups (alongside the existing `when` logic), and threads the skipped-checks set into `executeGroup` for both projects and sub-projects (they share `project.Path`).
- **`pkg/checker/group.go`** — `executeGroup` omits checks listed in the skip set.

### Behavior
- Both `groups` and `checks` are optional.
- Skipped checks are not executed and emit **no** Prometheus metric. Since gauges reset each tick (#95), no stale values result.
- **Fails open**: a missing file skips nothing; a malformed file logs a warning and runs all checks — a broken opt-out never silently disables enforcement.

## Tests
- New `pkg/checker/skipconfig_test.go` — loader cases (missing / valid / only-checks / only-groups / malformed).
- Extended `pkg/checker/checker_test.go` — end-to-end `TestRunWithSkipConfig` asserting a skipped check and a skipped group are omitted from results.
- `go test ./...` (30 pass), `go vet ./...` clean, `golangci-lint` v1.64.2 (CI-pinned) clean.

## Docs
- README: new "Per-repository skip configuration" section.
- `config.example.yaml`: commented reference to the per-repo file.